### PR TITLE
Use option builder: "dirhtml"

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
 sphinx:
   configuration: conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-  # builder: "dirhtml"
+  builder: "dirhtml"
   # Fail on all warnings to avoid broken references
   # fail_on_warning: true
 


### PR DESCRIPTION
This is needed because of build changes within read the docs which caused older urls to be invalid. Here are 2 examples

`https://docs.menandmice.com/en/10.3/release_notes/` should be `https://docs.menandmice.com/en/latest/release_notes.html#id38`

`https://docs.menandmice.com/en/latest/guides/reference/ip_count/#calculating-ip-usage` should be `https://docs.menandmice.com/en/latest/guides/reference/ip_count.html`

This change should remove the .html part at least, making the older urls valid again