### PR TITLE
Revised the text

### DIFF
--- a/guides/implementation/generic_dns_controller.rst
+++ b/guides/implementation/generic_dns_controller.rst
@@ -7,22 +7,22 @@
 Generic DNS Agent
 ==================
 
-The generic DNS agent is compatible with both native ISC BIND DNS and Windows DNS servers, providing increased flexibility and allowing communication with new types of DNS servers.
+The generic DNS agent is compatible with other native DNS servers, providing increased flexibility and allowing communication with new types of DNS servers.
 
 **To install and configure the Generic DNS agent**:
 
 1. Install:
 
-   * **Windows**: Run the agent installer (x32 or x64 - depending on your OS version). There is no separate installer for the generic agent - simply use the standard agent installer.
+   * **Windows**: Run the agent installer. There is no separate installer for the generic agent - simply use the standard agent installer.
 
    * **Unix**: Run the agent installer with the parameter ``--generic-dns-controller``.
 
-2. Install a script interpreter. We recommend using Python (version 2.7.x) script interpreter. Micetro provides example connector scripts for Python.
+2. Install a script interpreter. We recommend using Python (version 3.8 or later) script interpreter. Micetro provides example connector scripts for Python.
 
 3. Add the ``GenericDNSScript`` XML tag to the ``preferences.cfg`` file. If the file doesn't exist, create it.
 
   .. note::
-    On Windows 2008/2012 R2, the ``preferences.cfg`` file is located in the hidden directory ``C:\ProgramData\Men and Mice\DNS Server agent``.
+    On Windows, the ``preferences.cfg`` file is located in the hidden directory ``C:\ProgramData\Men and Mice\DNS Server Controller``
 
 4. Use the following example configuration for the Python interpreter and a connector script located on the C drive in the scripts sub-directory:
 
@@ -39,7 +39,7 @@ Limitations
 
 * The API does not yet support reading, modifying zone/server options, reading logs, clearing cache, or controlling the server itself.
 
-* Depending on the connector script, only primary zones are currently supported. Secondary zones or special zones such as forward or stub zones are supported for Amazon Route53, but secondary zones are supported for :ref:`powerdns`.
+* Depending on the connector script, only primary zones are currently supported. Secondary zones are supported for :ref:`powerdns`.
 
 .. note::
   The connector script can interface with a secondary zone and return an error when Central attempts to update the zone. However, the zone will appear as a "Primary" in Micetro. 


### PR DESCRIPTION
Revised the text. On the documentation page the reference for genericDNS.py seems to be broken.
Question also if it should be referring 10.1 or just the latest?

- Martin will be adding a new version of the PowerDNS script. He is working on the documentation. So the reference to configuring PowerDNS has to be fixed.
- Question if we should allow downloads for AWS and the old PowerDNS script also so users can look through code and perhaps reuse something.