### PR TITLE
Central server is now fixed/locked by default

### DIFF
--- a/guides/implementation/webapp_fixed_central.rst
+++ b/guides/implementation/webapp_fixed_central.rst
@@ -1,60 +1,45 @@
 .. meta::
-   :description: Setting a static value for Micetro Central in the Micetro Web Interface
+   :description: Allowing Micetro Web Interface to login to other Central servers.
    :keywords: Micetro 
 
 .. _webapp-fixed-central:
 
-Configuring the Web Interface to Use a fixed Micetro Central Server
+Allowing Micetro Web Interface to login to other Central servers
 ===================================================================
 
-By default, the Micetro Web Interface allows you to select the Micetro Central server for login. If you want to set a fixed Micetro Central Server for the login dialog box, follow the steps below.
+By default, the Micetro Web Interface and API only allow connecting to a single Micetro Central server, determined during the first login to Micetro after installation.
+
+If you want to allow users to specify a custom Central server to connect to, follow the instructions below.
 
 Windows
 -------
 
-**To configure a fixed Server name for the Web Interface login**:
-
-1. Edit the ``preferences.cfg`` file for the M&M Web Services located at ``c:\\ProgramData\\Men and Mice\\Web Services\\preferences.cfg``. If it doesn't exist, insert an XML-Tag for the default Micetro Central server name:
+1. Edit the ``preferences.cfg`` file for the M&M Web Services located at ``c:\\ProgramData\\Men and Mice\\Web Services\\preferences.cfg``. Add the following XML tag
 
   .. code-block::
 
-    <DefaultCentralServer value="your M&M Central DNS name or IP" />
+    <LockToDefaultServer value="0" />
 
-2. Add an XML tag to set the Web Interface to use the DefaultCentralServer as a fixed server name:
+2. Restart the M&M Web Services Windows service.
 
-  .. code-block::
-
-    <FixedCentralServer value="1" />
-
-3. Restart the M&M Web Services Windows service.
-
-4. After that, the login dialog box will display the DefaultCentralServer name as "Server", which will be greyed out and uneditable.
-
-.. tip::
-  It's a good idea to clear the browser's cached cookies and reload the Web Interface page to ensure the correct data is displayed.
+3. After that, a "Server" field will appear in the Micetro Web Interface login page, and the "serverName" field in the API Login command will be honored
 
 Linux
 -----
 
 1. Log into the server hosting the Web Interface.
 
-2. Edit the ``preferences.cfg`` file for the M&M Web Services (``/var/mmsuite/web_services/preferences.cfg``). Add an XML tag for the default Micetro Central server name if it's missing:
+2. Edit the ``preferences.cfg`` file for the M&M Web Services (``/var/mmsuite/web_services/preferences.cfg``). Add the following XML tag
 
   .. code-block::
 
-    <DefaultCentralServer value="your M&M Central DNS name or IP" />
+    <LockToDefaultServer value="0" />
 
-3. Add an XML tag to set the Web Interface to use the DefaultCentralServer as fixed server name:
-
-  .. code-block::
-
-    <FixedCentralServer value="1" />
-
-4. Restart the ``mmws`` service:
+3. Restart the ``mmws`` service:
 
   .. code-block:: bash
 
     systemctl restart mmws
 
-.. tip::
-  It's a good idea to clear the browser's cached cookies and reload the Web Interface page to ensure the correct data is displayed.
+4. After that, a "Server" field will appear in the Micetro Web Interface login page, and the "serverName" field in the API Login command will be honored
+

--- a/guides/management-console/external_auth.rst
+++ b/guides/management-console/external_auth.rst
@@ -553,14 +553,3 @@ Logging for External Authentication can be enabled by putting your Central log i
 **External changes to user profiles**
 
 External changes to the user’s email, full name, and group membership are automatically replicated in Micetro on the next login.
-
-**Separate hosts for Micetro Central and Micetro Web Application**
-
-The Web Application/Web service is traditionally on the same host as the Micetro Central and by default, the tool will send queries to “localhost”.  
-
-if Micetro Central is on a different host from the Web Service then you can add the following XML-tag to the preference value to auto-populate the “Server” field at login::
-
-      <DefaultCentralServer value="IP or DNS name of the Men & Mice Central server" />
-      
-      * Windows - C:\ProgramData\Men and Mice\Central\preferences.cfg 
-      * Linux - /var/mmsuite/mmcentral/preferences.cfg


### PR DESCRIPTION
Change documentation around fixing Central server, to document how to un-fix it, since it's now fixed by default and the preference key to unlock is different (the old preference key  FixedCentralServer no longer in use)