### PR TITLE
Add release notes for 11.0.4

### DIFF
--- a/guides/implementation/architecture.rst
+++ b/guides/implementation/architecture.rst
@@ -208,4 +208,4 @@ The Micetro Web Interface can be installed on any server on the network running 
 Virtual Appliances (Optional)
 ------------------------------
 
-The BDDS DNS/DHCP Appliance can be used as both a DNS and a DHCP server. Once the appliance has been configured, you work with the DNS and DHCP servers just as you would work with the BIND and ISC DHCP servers. See :ref:`webapp-appliance-management` for more information.
+The MDDS DNS/DHCP Appliance can be used as both a DNS and a DHCP server. Once the appliance has been configured, you work with the DNS and DHCP servers just as you would work with the BIND and ISC DHCP servers. See :ref:`webapp-appliance-management` for more information.

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -27,7 +27,6 @@ Bug Fixes
 * Fixed an issue where unintended user input in the filter field caused Central to stop.
 * Resolved a problem where a field name in filters would be matched to a column even if it was only a partial match.
 * Fixed a regression that allowed users to modify the names and descriptions of built-in groups.
-* Enabled scope conversion in the eBay-specific version of the Micetro Web Interface.
 * Fixed the import of TXT records that contain semicolons.
 * The ``AddDHCPReservation`` function no longer supports referencing reservations by name for Kea.
 * Change requests can now reference reservations by address, in addition to name. For ISC reservations with multiple addresses, the system will now verify if any of the addresses match.

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -11,7 +11,26 @@ Release Notes
   Major releases are only supported for 2 years.
 
 
-Jump to: :ref:`10.3-release`, :ref:`10.3.1-release`, :ref:`10.3.2-release`, :ref:`10.3.3-release`, :ref:`10.3.4-release`, :ref:`10.3.5-release`, :ref:`10.3.6-release`, :ref:`10.3.8-release`, :ref:`10.3.9-release`, :ref:`10.3.10-release`, :ref:`10.3.11-release`, :ref:`10.3.12-release`, :ref:`10.5.0-release`, :ref:`10.5.1-release`,  :ref:`10.5.2-release`, :ref:`10.5.3-release`, :ref:`10.5.4-release`, :ref:`10.5.5-release`, :ref:`10.5.6-release`, :ref:`10.5.7-release`, :ref:`10.5.8-release`, :ref:`11.0.0-release`, :ref:`11.0.1-release`, :ref:`11.0.2-release`, :ref:`11.0.3-release`
+Jump to: :ref:`10.3-release`, :ref:`10.3.1-release`, :ref:`10.3.2-release`, :ref:`10.3.3-release`, :ref:`10.3.4-release`, :ref:`10.3.5-release`, :ref:`10.3.6-release`, :ref:`10.3.8-release`, :ref:`10.3.9-release`, :ref:`10.3.10-release`, :ref:`10.3.11-release`, :ref:`10.3.12-release`, :ref:`10.5.0-release`, :ref:`10.5.1-release`,  :ref:`10.5.2-release`, :ref:`10.5.3-release`, :ref:`10.5.4-release`, :ref:`10.5.5-release`, :ref:`10.5.6-release`, :ref:`10.5.7-release`, :ref:`10.5.8-release`, :ref:`11.0.0-release`, :ref:`11.0.1-release`, :ref:`11.0.2-release`, :ref:`11.0.3-release`, :ref:`11.0.4-release`
+
+.. _11.0.4-release:
+
+11.0.4
+------
+September 16, 2024
+
+Bug Fixes
+^^^^^^^^^
+* Resolved a problem that prevented users from logging into the Micetro Web Interface following an upgrade to a new license key version when the default home page was configured to the DNS or IPAM view.
+* Fixed an issue where the DNS server list (DHCP option 6 on MS DHCP) in the Micetro Web Interface was previously sorting by IP address instead of the user-defined order. The order of DNS servers in DHCP option 6 is now preserved in the Web Interface.
+* Resolved an issue where field validation failed during DHCP scope conversion:
+* Fixed an issue where unintended user input in the filter field caused Central to stop.
+* Resolved a problem where a field name in filters would be matched to a column even if it was only a partial match.
+* Fixed a regression that allowed users to modify the names and descriptions of built-in groups.
+* Enabled scope conversion in the eBay-specific version of the Micetro Web Interface.
+* Fixed the import of TXT records that contain semicolons.
+* The ``AddDHCPReservation`` function no longer supports referencing reservations by name for Kea.
+* Change requests can now reference reservations by address, in addition to name. For ISC reservations with multiple addresses, the system will now verify if any of the addresses match.
 
 .. _11.0.3-release:
 


### PR DESCRIPTION
Adding the release notes from 11.0.4 into 11.1 so that they will be part of the 11.1 documentation once that version will be released