### PR TITLE
Typo fixes in the HA page

### DIFF
--- a/guides/implementation/central_ha.rst
+++ b/guides/implementation/central_ha.rst
@@ -140,7 +140,7 @@ Windows
 12. Start Central on the secondary server:
 
   * Open the Services window by pressing **Win + R**, typing **services.msc**, and hitting Enter.
-  * Locate the Micetro Central service, right-click on it, and select **Stop** to ensure it's not running.
+  * Locate the Micetro Central service, right-click on it, and select **Start** and ensure it's running.
 
 13. Verify that you now have 2 servers: one primary, one secondary in :menuselection:`Tools --> Manage High availability`.
 


### PR DESCRIPTION
There was a typo in the HA section page for Micetro.

These have now been fixed.