### PR TITLE
MM-21802. Add failed login throttle info

### DIFF
--- a/guides/admin-manual/access_control.rst
+++ b/guides/admin-manual/access_control.rst
@@ -55,6 +55,10 @@ Failed login attempts
 
 To protect users from brute force password attacks, Micetro throttles unsuccessful login attempts. 
 
+.. note::
+  This only applies to internal Micetro users.
+
+
 New objects
 -----------
 

--- a/guides/admin-manual/access_control.rst
+++ b/guides/admin-manual/access_control.rst
@@ -49,6 +49,12 @@ The password for the ``administrator`` user is configured during the :ref:`first
 
 The ``administrator`` user cannot be removed from Micetro, and is always local (cannot be authenticated by SSO).
 
+
+Failed login attempts
+---------------------
+
+To protect users from brute force password attacks, Micetro throttles unsuccessful login attempts. 
+
 New objects
 -----------
 


### PR DESCRIPTION
Added section on failed login attempts to address how Micetro protects from password attacks.