### PR TITLE
Added sphinx tabs extension.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx_tabs.tabs",
 ]
 
 intersphinx_mapping = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ recommonmark==0.5.0
 sphinx
 sphinx-rtd-theme
 readthedocs-sphinx-ext<2.3
+sphinx-tabs


### PR DESCRIPTION
With this change, we can add tabs to our doc page formatting, to toggle between two types of the same item, e.g., code block, without needing to scroll to individual sections.