### PR TITLE
Don't document failover APIs

### DIFF
--- a/guides/admin-manual/failover_management_isc.rst
+++ b/guides/admin-manual/failover_management_isc.rst
@@ -12,8 +12,6 @@ Viewing Existing ISC DHCP Failover Relationships
 ------------------------------------------------
 You can view existing ISC DHCP failover relationships at the server level. Micetro automatically detects and syncs all existing failover relationships.
 
-You can retrieve failover relationships through the API using ``GetDHCPFailoverRelationship(s)``. 
-
 **To view failover relationships in Micetro**:
 
 1.	On the **Admin** page, select :guilabel:`Service Management` in the upper-left corner.
@@ -39,22 +37,6 @@ While ISC DHCP servers handle operations at the DHCP pool level, Micetro manages
 
 .. note::
    When the first scope is added to the failover relationship, the failover peer statement is created on the server. All address pools within the scope will be updated to refer to this failover peer.
-
-**To create a failover relationship through the API**:
-
-API supports creation using ``AddDHCPFailoverRelationship``.
-
-The following parameters are used for the ``AddDHCPFailoverRelationship`` command:
-
-* **Name**: The name of the DHCP failover relationship to be created.
-* **PrimaryServer**: The name of the primary DHCP server as it appears in Micetro.
-* **SecondaryServer**: The name of the secondary DHCP server as it appears in Micetro.
-* **Percentage**: Indicates the percentage of the DHCPv4 client load that will be shared between the primary and secondary servers in the failover relationship.
-* **Mclt**: Specify the number of seconds for which a lease can be renewed by either server without contacting the other.
-* **Port**: Specify the port number on which the server should listen for connections from its failover peer.
-* **LoadBalanceMaxSeconds**: Specify the cutoff in seconds after which load balancing is disabled. According to ISC documentation, a value of 3 or 5 is recommended.  
-* **MaxResponseDelay**: Specify the number of seconds that may pass without the server receiving a message from its failover peer before it assumes that the connection has failed.
-* **MaxUnackedUpdates**: Specify the number of messages the server can send before receiving an acknowledgment from its failover peer. According to ISC documentation, 10 seems to be a good value.
 
 **To create a failover relationship in Micetro**:
 
@@ -108,10 +90,6 @@ Once you have added a scope, the failover peer statement will automatically be a
    .. image:: ../../images/failover-create-scope.png
       :width: 80%
 
--OR-
-
-* API offers ``AdsdDHCPScopesFromDHCPFailoverRelationship`` which adds scopes to failover relationships. Specify a reference to the DHCP Scope and the failover relationship name.
-
 .. note::
    At least one pool must exist in the scope before adding it to the failover relationship.
 
@@ -143,9 +121,6 @@ ISC DHCP scopes participating in failover relationships are grouped and labeled 
    .. image:: ../../images/failover-isc-remove-scope-instance.png
       :width: 80%
 
--OR-
-
-* The API offers ``RemoveDHCPScopesFromDHCPFailoverRelationship`` which removes scopes to failover relationships. Just specify a reference to the DHCP Scope, the failover relationship name, and the proper deconfigure action.
 
 Modifying Failover Relationships
 --------------------------------
@@ -157,19 +132,6 @@ You can modify ISC failover relationship options on a per-relationship basis.
 2.	Select the relevant relationship, and then select :guilabel:`Edit` on the Row :guilabel:`...` menu.
 3.	Make the desired changes and select :guilabel:`Save`.
 
--OR-
-
-* The API offers ``ModifyDHCPFailoverRelationship``. The following parameters are used for the ``ModifyDHCPFailoverRelationship`` command:
-
-   *	**Name**: The name of the DHCP failover relationship to be created.
-   *	**PrimaryServer**: The name of the primary DHCP server as it appears in Micetro.
-   *	**SecondaryServer**: The name of the secondary DHCP server as it appears in Micetro.
-   *	**Mclt**: Specify the number of seconds for which a lease can be renewed by either server without contacting the other.
-   *	**Port**: Specify the port number on which the server should listen for connections from its failover peer.
-   *	**LoadBalanceMaxSeconds**: Specify the cutoff in seconds after which load balancing is disabled. According to ISC documentation, a value of 3 or 5 is recommended.  
-   *	**MaxResponseDelay**: Specify the number of seconds that may pass without the server receiving a message from its failover peer before it assumes that the connection has failed.
-   *	**MaxUnackedUpdates**: Specify the number of messages the server can send before receiving an acknowledgment from its failover peer. According to ISC documentation, 10 seems to be a good value.
-
 Removing Failover Relationships
 --------------------------------
 
@@ -178,10 +140,6 @@ Removing Failover Relationships
 1.	Go to the :guilabel:`Service Management` tab on the **Admin** page, select the server containing the relationship you want to remove, and then select :guilabel:`Failover management` either on the :guilabel:`Action` or the Row :guilabel:`...` menu.
 2.	Select the relevant relationship, and then select :guilabel:`Remove`  on the Row :guilabel:`...` menu. 
 3.	Decide whether to delete or disable the secondary scopes. 
-
--OR-
-
-* The API offers ``RemoveDHCPFailoverRelationships``. Specify a reference to the ISC DHCP service, the name of the failover relationship, and the proper deconfigure action.
 
 Address Pool Failover Display
 ------------------------------

--- a/guides/admin-manual/failover_management_kea.rst
+++ b/guides/admin-manual/failover_management_kea.rst
@@ -169,8 +169,6 @@ Viewing Kea DHCP Failover Relationships
 ---------------------------------------
 You can view existing Kea DHCP failover relationships at the server level. Micetro automatically detects and syncs all existing failover relationships. 
 
-You can retrieve failover relationships through the API using the ``GetDHCPFailoverRelationship``.
-
 **To view failover relationships in Micetro**:
 
 1.	On the **Admin** page, select :guilabel:`Service Management` in the upper-left corner.
@@ -198,18 +196,6 @@ Each Kea DHCP server supports the creation of one Kea DHCPv4 and one Kea DHCPv6 
 If a Kea DHCP server functions as a secondary server in a failover relationship, creating additional relationships with it as a primary server is not possible.
 
 Micetro currently supports two failover server types in a relationship: one primary and one secondary. Therefore, creating failover relationships with backup servers is not supported.
-
-**To create a failover relationship through the API**:
-
-API supports creation using ``AddDHCPFailoverRelationship``.
-
-The following parameters are used for the ``AddDHCPFailoverRelationship`` command:
-
-* **Name**: The name of the DHCP failover relationship to be created.
-* **PrimaryServer**: The name of the primary DHCP server as it appears in Micetro.
-* **SecondaryServer**: The name of the secondary DHCP server as it appears in Micetro.
-* **FailoverMode**: The DHCP failover mode to use.
-* **ServiceType**: DHCPv4 or DHCPv6, defaults to DHCPv4.
 
 **To create a failover relationship in Micetro**:
 
@@ -250,7 +236,3 @@ Removing Failover Relationships
 1.	Go to the :guilabel:`Service Management` tab on the **Admin** page, select the server containing the relationship you want to modify, and then select :guilabel:`Failover management` either on the :guilabel:`Action` or the Row :guilabel:`...` menu.
 2.	Select the relevant relationship, and then select :guilabel:`Remove` on the Row :guilabel:`...` menu.
 3.	Decide whether to delete or disable the secondary scopes.
-
-   -OR-
-
-   * The API offers ``RemoveDHCPFailoverRelationships``. Just specify a reference to the Kea DHCP service, the name of the failover relationship, and the proper deconfigure action.

--- a/guides/admin-manual/failover_management_windows.rst
+++ b/guides/admin-manual/failover_management_windows.rst
@@ -20,8 +20,6 @@ Viewing Existing Microsoft DHCP Failover Relationships
 ------------------------------------------------------
 You can view existing Microsoft DHCP failover relationships at the server level. Micetro automatically detects and syncs all existing failover relationships. 
 
-You can retrieve failover relationships through the API using GetDHCPFailoverRelationship(s). 
-
 **To view failover relationships in Micetro**:
 
 1.	On the **Admin** page, select :guilabel:`Service Management` in the upper-left corner.
@@ -38,21 +36,6 @@ Creating Failover Relationships for Microsoft DHCP
 Micetro manages failover relationships at both the scope and server levels. Scopes group IP addresses logically and help to manage failover efficiently. DHCP configurations can be customized per scope to suit the specific requirements of different network segments.
 
 When creating failover relationships for Microsoft DHCP servers, scopes are not added to the relationship at the time of creation. Instead, the scopes are added later by using the :guilabel:`Add scope to failover` action.
-
-**To create a failover relationship through the API**
-
-API supports creation using ``AddDHCPFailoverRelationship``.
-
-The following parameters are used for the ``AddDHCPFailoverRelationship`` command:
-
-* **Name**: The name of the DHCP failover relationship to be created.
-* **PrimaryServer**: The name of the primary DHCP server as it appears in Micetro.
-* **SecondaryServer**: The name of the secondary DHCP server as it appears in Micetro.
-* **FailoverMode**: The DHCP failover mode to use.
-* **Mclt**: Specify the number of seconds for which either server can renew a lease without contacting the other.
-* **SafePeriod**: Safe period time in seconds, that the DHCPv4 server will wait before transitioning the server from the COMMUNICATION-INT state to PARTNER-DOWN.
-* **Percentage**: Indicates the percentage of the DHCPv4 client load that will be shared between the primary and secondary servers in the failover relationship.
-* **SharedSecret**: The shared secret key associated with this failover relationship.
 
 **To create a failover relationship in Micetro**:
 
@@ -104,10 +87,6 @@ If the failover relationship was previously empty, it will be created on the Mic
    .. image:: ../../images/failover-create-scope.png
       :width: 80%
 
--OR-
-
-* API offers ``AdsdDHCPScopesFromDHCPFailoverRelationship`` which adds scopes to failover relationships. Specify a reference to the DHCP Scope and the failover relationship name.
-
 If the failover relationship was empty before the scope was added to it, the status will change from “Empty” to “Normal”.
 
 .. image:: ../../images/failover-state-microsoft.png
@@ -133,10 +112,6 @@ Microsoft DHCP scopes participating in failover relationships are grouped and la
    .. image:: ../../images/failover-microsoft-remove-scope-instance.png
       :width: 805%
 
--OR-
-
-* The API offers ``RemoveDHCPScopesFromDHCPFailoverRelationship`` which removes scopes to failover relationships. Specify a reference to the DHCP Scope, the failover relationship name, and the proper deconfigure action.
-
 Modifying Failover Relationships
 --------------------------------
 You can modify ISC failover relationship options on a per-relationship basis. 
@@ -146,19 +121,6 @@ You can modify ISC failover relationship options on a per-relationship basis.
 1.	Go to the :guilabel:`Service Management` tab on the **Admin** page, select the server containing the relationship you want to modify, and then select :guilabel:`Failover management` either on the :guilabel:`Action` or the Row :guilabel:`...` menu.
 2.	Select the relevant relationship, and then select :guilabel:`Edit` on the Row :guilabel:`...` menu.
 3.	Make the desired changes and select :guilabel:`Save`.
-
--OR-
-
-* The API offers ``ModifyDHCPFailoverRelationship``. The following parameters are used for the ``ModifyDHCPFailoverRelationship`` command:
-
-   * **Name**: The name of the DHCP failover relationship to be created.
-   * **PrimaryServer**: The name of the primary DHCP server as it appears in Micetro.
-   * **SecondaryServer**: The name of the secondary DHCP server as it appears in Micetro.
-   * **FailoverMode**: The DHCP failover mode to use.
-   * **Mclt**: Specify the number of seconds for which either server can renew a lease without contacting the other.
-   * **SafePeriod**: Safe period time in seconds, that the DHCPv4 server will wait before transitioning the server from the COMMUNICATION-INT state to PARTNER-DOWN.
-   * **Percentage**: Indicates the percentage of the DHCPv4 client load that will be shared between the primary and secondary servers in the failover relationship.
-   * **SharedSecret**: The shared secret key associated with this failover relationship.
 
 
 Removing Failover Relationships 


### PR DESCRIPTION
It's not consistent with the rest of the documentation to do so, inline with the UI documentation.

It was often just repeating the documentation for the corresponding UI fields.

It was also not accurate  (noticed typos, and instead of fixing, decided to remove)