### PR TITLE
Removed DynDNS and Unbound.

### DIFF
--- a/guides/admin-manual/webapp_server_management.rst
+++ b/guides/admin-manual/webapp_server_management.rst
@@ -56,15 +56,11 @@ Micetro supports the following DNS and DHCP platforms:
 
   * BIND
 
-  * DynDNS (cloud), (Note DynDNS is EOL May 31st 2023)
-
   * Edge DNS (cloud)
 
   * Microsoft DNS
 
   * NS1 (cloud)
-
-  * Unbound (deprecated, new services cannot be added)
 
   * Micetro DDS Appliance
 


### PR DESCRIPTION
Removed DynDNS and Unbound from Supported Services list, as they were deprecated in 11.0 and 11.1, respectively.