### PR TITLE
OBDC driver version note callout

### DIFF
--- a/guides/implementation/central_database_windows.rst
+++ b/guides/implementation/central_database_windows.rst
@@ -36,7 +36,10 @@ Microsoft SQL Server
  
     Micetro does not automatically perform index maintenance or database backups. It is recommended to have a database administrator set up a scheduled task to maintain indexes and regularly back up the database and transaction logs (when using the Full recovery model).
  
-Micetro requires the creation of a new database on your server with a case-sensitive and accent-sensitive collation. For SQL Server 2019 or later, it is recommended to use a UTF-8 collation, such as ``Latin1_General_100_CS_AS_KS_WS_SC_UTF8``. For earlier SQL Server versions or Micetro versions 11.0 and below, the recommended collation is ``SQL_Latin1_General_CP1_CS_AS``. We recommend using the `Microsoft ODBC driver <https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server>`_ --- either version 17 or 18 --- for SQL Server. This is required when using UTF-8 encoded collations. Otherwise, Micetro will connect to a database using older drivers, which could result in issues such as degraded performance.
+Micetro requires the creation of a new database on your server with a case-sensitive and accent-sensitive collation. For SQL Server 2019 or later, it is recommended to use a UTF-8 collation, such as ``Latin1_General_100_CS_AS_KS_WS_SC_UTF8``. For earlier SQL Server versions or Micetro versions 11.0 and below, the recommended collation is ``SQL_Latin1_General_CP1_CS_AS``.
+
+.. note::
+    We recommend using the `Microsoft ODBC driver <https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server>`_ **version 17 or 18** for SQL Server. This is required when using UTF-8 encoded collations. Otherwise, Micetro will connect to a database using older drivers, which could result in issues such as degraded performance.
 
 The `CreateDatabase.sql <https://github.com/menandmice/micetro_docs/blob/latest/scripts/CreateDatabase.sql>`_ script can be used to create a blank database for Micetro with the recommended configurations. The script also creates a user account called ``micetroDBUser``, but you must change the password before running the script. 
  

--- a/guides/implementation/central_mssql.rst
+++ b/guides/implementation/central_mssql.rst
@@ -30,7 +30,6 @@ Running the script will result in:
 
 Configuring Connection Parameters
 """""""""""""""""""""""""""""""""
-.. _central-mssql-windows:
 
 .. note::
    To improve your compatibility with Microsoft SQL Server, you need to `install ODBC driver on the Central server <https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver15>`_.


### PR DESCRIPTION
Made the recommended OBDC driver version more visible in a note. And resolved a linking/cross-reference issue.