### PR TITLE
DOC-3084. Fixed broken links in Free Trial Checklist.

### DIFF
--- a/guides/reference/free_trial_checklist.rst
+++ b/guides/reference/free_trial_checklist.rst
@@ -6,29 +6,31 @@
 
 Free Trial Checklist
 ---------------------
-Copy this or print it out to make sure you're getting the most out of your Micetro Free Trial.
+Copy or print out this checklist to make sure you're getting the most out of your Micetro Free Trial.
 
-[ ] Enter IPAM data either via import, discovery, or through manual entry. For help see video here: https://www.youtube.com/watch?v=RVRDdaOfq5U&t=77s
+[ ] Enter IPAM data either through import, discovery, or manual entry. For help, refer to this video on `Adding IPAM information <https://www.youtube.com/watch?v=RVRDdaOfq5U&t=77s>`_.
 
-[ ] Connect to any DNS and/or DHCP services required for testing and/or production. See videos here: https://www.youtube.com/playlist?list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU
+[ ] Connect to any DNS and/or DHCP services required for testing and/or production. Refer to the `Micetro Deployment tutorial videos <https://www.youtube.com/playlist?list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU>`_.
 
-[ ] Add AD Sites (optional). See documentation here: https://docs.menandmice.com/en/latest/guides/user-manual/ipam.html#active-directory
+[ ] Add AD Sites (optional). For information on adding AD sites, refer to :ref:`active-directory`.
 
-[ ] Integrate with AWS Route 53 and/or Azure DNS (if you are using either in your environment). AWS: https://www.youtube.com/watch?v=ANScAI0ltZA&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=10 
-Azure DNS: https://www.youtube.com/watch?v=DFfp9odIiqE&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=13
+[ ] Integrate with AWS Route 53 and/or Azure DNS (if you are using either in your environment). Refer to the following videos for more information:
 
-[ ] Check data quality and explore ways to reclaim IP space utilization. Please see this article for ideas on how to get started: https://docs.menandmice.com/en/latest/guides/reference/ip_count.html
+   * AWS: `Connecting to AWS Route 53 <https://www.youtube.com/watch?v=ANScAI0ltZA&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=10>`_ 
+   * Azure DNS: `Connecting to Azure DNS <https://www.youtube.com/watch?v=DFfp9odIiqE&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=13>`_
 
-[ ] Setup SNMP profiles for network discovery. See video here: https://www.youtube.com/watch?v=QAXmYRQluz8&t=1s
+[ ] Check your IP data quality and explore ways to reclaim IP space utilization. Refer to the :ref:`ip-count` reference article for ideas on how to get started.
 
-[ ] Setup discovery schedules. See video here: https://www.menandmice.com/ddi-talks/nU1kcoXnq9w
+[ ] Set up SNMP profiles for network discovery. Refer to this video on Micetro's `SNMP profiles capability <https://www.youtube.com/watch?v=QAXmYRQluz8&t=1s>`_.
 
-[ ] Create Micetro accounts and define access permissions. See video here: https://www.youtube.com/watch?v=aMEBxkg3bTQ&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=13
+[ ] Set up discovery schedules. Refer to the documentation on :ref:`host-discovery-networks` for more information.
 
-[ ] Define and create custom properties for asset management. See webinar here: https://www.youtube.com/watch?v=eHjGYbYqugQ&t=12s
+[ ] Create Micetro accounts and define access permissions. Refer to the video tutorial on `Role-based Access Control <https://www.youtube.com/watch?v=aMEBxkg3bTQ&list=PLg9woNoZKJM1wN3fVjUxLndMwtiIT3FkU&index=13>`_.
 
-[ ] Familiarize yourself with the APIs (optional). For help see playlist here: https://www.youtube.com/playlist?list=PLg9woNoZKJM0Vgugsm0PFkjs5ll_VQx-a
+[ ] Define and create custom properties for asset management. Refer to this webinar on `Multi-Cloud Asset Management <https://www.youtube.com/watch?v=eHjGYbYqugQ&t=12s>`_.
 
-[ ] Start using DNS Workflow to test automated approval workflows built-in to the UI. This video refers to Microsoft enhancement, but works the same with all DNS services. https://www.youtube.com/watch?v=FwxTcAivsGw&list=PLg9woNoZKJM3cndRlKC8ZScc8kTfJP8-E&index=11
+[ ] (Optional) Familiarize yourself with the APIs. For more information, refer to the videos in the `Automation with Micetro playlist <https://www.youtube.com/playlist?list=PLg9woNoZKJM0Vgugsm0PFkjs5ll_VQx-a>`_.
 
-[ ] Start using xDNS for multi-service DNS redundancy. For help see video here: https://www.youtube.com/watch?v=0mhRVOdRZfo&t=8s
+[ ] Start using Micetro Workflow to test automated approval workflows built into the Web Application. `This video <https://www.youtube.com/watch?v=8XAKYsefqME&list=PLg9woNoZKJM3cndRlKC8ZScc8kTfJP8-E&index=2>`_ refers to Microsoft enhancement, but works the same with all DNS services.
+
+[ ] Start using xDNS profiles for multi-service DNS redundancy. For more information, refer to this video on `achieving redundancy with xDNS <https://www.youtube.com/watch?v=Qu28AVhivjU&list=PLMqKtWApXlOhzytZbZ6VsOOE19BMhAl9f&index=1>`_.

--- a/guides/user-manual/networks.rst
+++ b/guides/user-manual/networks.rst
@@ -273,6 +273,7 @@ With this feature, you can select and merge multiple networks. The :guilabel:`Jo
 
 4. Click :guilabel:`Join`.
 
+.. _host-discovery-networks:
 
 Host Discovery
 ---------------


### PR DESCRIPTION
Fixed the broken links to documentation and videos.

Needed to replace a couple with documentation or BlueCat YouTube account videos (host discovery and xDNS profiles) due to inability to find video and availability of more recent content, respectively.