### PR TITLE
DOC-3089. Fixed Central HA configuration info.

### DIFF
--- a/guides/implementation/central_ha.rst
+++ b/guides/implementation/central_ha.rst
@@ -12,144 +12,207 @@ Failover instances of Micetro Central can be configured to build a High Availabi
 .. note::
   * To run Micetro in High Availability mode, you must be using the MS SQL or PostgreSQL database backend for Micetro. High Availability mode is not available for other database types.
   
-  * All participating servers should use the same NTP server. If not, one standby server may start to take over, since the timestamp for the active server will be old, and lead the NTP server to think the active server is offline.
+  * All participating Micetro Central HA servers should have NTP configured. Clocks that are out-of-sync can cause unwanted failovers.
 
 When there are no HA members defined or if Micetro Central has not been configured for HA, a message will appear, indicating further configuration is necessary. This documentation provides instructions on how to configure HA in Micetro for versions 10.2 and above. If you need to use the management console (thick client), please refer to the `documentation for version 10.1 <https://docs.menandmice.com/en/10.1/guides/implementation/central_ha/>`_.
 
-.. _central-ha-windows:
 
-Configuring High Availability on Windows
-----------------------------------------
+.. tabs::
 
-1. In the existing (or designated as *primary*) server running Micetro Central, edit the preferences file ``preferences.cfg`` by adding the following to the file:
+   .. tab:: Windows
 
-  .. code-block::
+    1. On the existing (or designated as *primary*) server running Micetro Central, edit the Micetro Central preferences file ``C:\ProgramData\Men and Mice\Central\preferences.cfg`` by adding the following XML-tag to the file:
 
-   <ClusterMemberName value="somename"/>
+      .. code-block::
 
-  ``somename`` is the unique name that will identify the Micetro Central instance in the High Availability cluster. (For example, "1", “primary”, or "central1".)
+        <ClusterMemberName value="somename" />
 
-2. Restart the primary Central application from the command line:
+      ``somename`` is the unique name that will identify the Micetro Central instance in the High Availability cluster, e.g., "1", “primary”, or "central1". Here's an example:
 
-  .. code-block:: bash
+      .. code-block::
+        
+        <ClusterMemberName value="primary" />
 
-    mmcentral.exe –stop
-    mmcentral.exe –start
+    2. Restart the primary Central application from the command line:
 
-3. Log into the Micetro Web Application as "administrator" and go to :menuselection:`Admin --> Configuration`.
+      * Open the **Services** window, e.g., by selecting **Win + R**, entering **services.msc**, and selecting **OK**.
+      * Locate the **Men and Mice Central service**, right-click on it, and select **Start** or **Restart**.
 
-4. Select :guilabel:`High Availability`.
+    3. Log into the Micetro Web Application as "administrator" and go to :menuselection:`Admin --> Configuration`.
 
-5. Enter the name of the first member server to match the name previously given and set the priority to **10**.
+    4. Select :guilabel:`High Availability`.
 
-6. Click :guilabel:`Add Member`.
+    5. Enter the name of the first member server to match the name previously given and set the priority to **10**. The name must match the name in the XML-tag ``ClustMemberName``, e.g., as in the example above as **primary**.
 
- .. image:: ../../images/ha-add-member.jpg
-   :width: 100%
+    6. Select :guilabel:`Add Member`.
+
+       .. image:: ../../images/ha-add-member.jpg
+        :width: 100%
   
-7. Restart Micetro Central from the command line:
+    7. Restart Micetro Central from the command line or through the ``services.msc``:
 
- .. code-block:: bash
+      * Open the **Services** window, e.g., by selecting **Win + R**, entering **services.msc**, and selecting **OK**.
+      * Locate the **Men and Mice Central service**, right-click on it, and select **Start** or **Restart**.
 
-   mmcentral.exe –stop
-   mmcentral.exe –start
+    8. Log into the Web Application and navigate to :menuselection:`Admin --> Configuration --> High Availability` to verify that the current server is running with state **Active**.
 
-8. Log into the Web Application and verify that the current server is running with state "Active".
+       .. image:: ../../images/ha-cluster.png
+        :width: 100%
 
-9. Repeat steps 3--6 to add another member to the HA configuration, but now use a priority of **20** or higher.
+    9. Repeat steps 3--6 to add another member to the HA configuration, but now use a priority of **20** or higher, e.g., add a secondary server with the name "secondary" and a priority of **20**.
 
-.. image:: ../../images/ha-cluster.png
-  :width: 70%
+       This adds the secondary server to the database. The configuration of the secondary Micetro Central server itself is done in the next steps.
 
-10. On the newly added secondary server, install Micetro Central. If it's already installed, make sure it's stopped:
+    10. On the newly added secondary server, install Micetro Central. If it's already installed, make sure it's stopped:
 
-  * Open the Services window by pressing **Win + R**, entering **services.msc**, and clicking **Enter**.
-  * Locate the Micetro Central service, right-click on it, and select **Stop** to make sure it's not running.
+      * Open the **Services** window by selecting **Win + R**, entering **services.msc**, and selecting **OK**.
+      * Locate the **Men and Mice Central service**, right-click on it, and select **Stop** to make sure it's not running.
 
-11. Copy the ``C:\ProgramData\Men and Mice\Central`` file from the first server to the second and change the ``ClusterMemberName`` value to contain the name of the secondary that was set up previously. Save the file and exit.
+    11. Copy the ``C:\ProgramData\Men and Mice\Central\preferences.cfg`` file from the first server (the **Active** one) to the new secondary server to replace the secondary server's existing ``preferences.cfg`` file.
 
-12. Start Micetro Central on the secondary server:
+        * Change the XML-tag ``ClusterMemberName`` value to the name of the secondary that was set up in Step 9 and save the changed file.
 
-  * Open the Services window by pressing **Win + R**, entering **services.msc**, and clicking **Enter**.
-  * Locate Micetro Central, right-click on it, and select **Start** to make sure it's running.
+      .. note::
+        The only difference between the primary (Active) and secondary server's ``preferences.cfg`` files should be the value of ``ClusterMemberName``, e.g., *secondary* instead of *primary*.
 
-13. Verify that you now have two servers: one primary and one secondary in :menuselection:`Tools --> Manage High availability`.
+    12. Start Micetro Central on the secondary server:
 
-14. Create a round robin DNS name for the High Availability setup. This involves creating two A records with the same name, each with the IP address of the primary and secondary server.
+      * Open the **Services** window by selecting **Win + R**, entering **services.msc**, and selecting **OK**.
+      * Locate **Men and Mice Central service**, right-click on it, and select **Start** to make sure it's running.
 
-.. note::
-  Repeat these steps for each High Availability failover relationship you'd like to add. The priority for each failover member should be unique and higher than the primary.
+    13. In the Web Application, navigate to :menuselection:`Admin --> Configuration --> High Availability` and verify that you now have two servers: one **Active** and one in a **Standby** state.
 
-----
+    14. Create a round robin DNS name for the High Availability setup. This involves creating two A records with the same name, each with the IP address of the primary and secondary server. For example:
 
-.. _central-ha-unix:
-
-Configuring High Availability on Linux
---------------------------------------
-
-1. On the existing (or designated as *primary*) server running Micetro Central, edit the preferences file in ``/var/mmsuite/mmcentral/preferences.cfg`` by adding the following to the file:
-
-  .. code-block::
-
-    <ClusterMemberName value="somename"/>
-
-  ``somename`` is the unique name that will identify the Micetro Central instance in the High Availability cluster. (For example "1", “primary”, or "central1".)
-
-2. Restart the primary Micetro Central application:
-
-  .. code-block:: bash
-
-    systemctl restart mmcentral
-
-3. Log into the Micetro Application as "administrator" and go to :menuselection:`Admin --> Configuration`.
-
-4. Select :guilabel:`High Availability`.
-
-5. Enter the name of the first member server to match the previously given name given and set the priority to **10**.
-
-6. Click :guilabel:`Add Member`.
-
-  .. image:: ../../images/ha-add-member.jpg
-    :width: 100%
-
-7. Restart Micetro Central:
-
-  .. code-block:: bash
-
-    systemctl restart mmcentral
-
-8. Log into the Micetro Web Application and verify that the current server is running with state "Active".
-
-9. Repeat steps 3--6 to add another member to the HA configuration, but now use a priority of **20** or higher.
-
-  .. image:: ../../images/ha-cluster.png
-    :width: 70%
-
-10. On the newly added secondary server, install Micetro Central. If it's already installed, make sure it's stopped by using (as root):
-
-  .. code-block:: bash
-
-    systemctl stop mmcentral
-    systemctl status mmcentral
-
-11. Copy the ``/var/mmsuite/mmcentral/preferences.cfg`` file from the first server to the second and change the ``ClusterMemberName`` value to contain the name of the secondary server that was set up previously. Save the file and exit.
-
-12. Start Micetro Central on the secondary server:
-
-  .. code-block:: bash
-
-    systemctl start mmcentral
-
-13. Verify that you now have two servers: one primary and one secondary in the HA cluster.
-
-14. Create a round robin DNS name for the High Availability setup. This involves creating two A records with the same name, each with the IP address of the primary and secondary server.
-
-.. note::
-  Repeat these steps for each High Availability failover you'd like to add. The priority for each failover member should be unique and higher than the primary.
-
-Proceed to :ref:`dns-agent-linux`.
-
+      .. code-block::
+        
+        micetrocentral.example.com A 192.168.2.53
+        micetrocentral.example.com A 192.168.2.54
   
+      in which ``192.168.2.53`` is the primary and ``192.168.2.54`` is the secondary. 
+
+      * Check whether the round robin name can be resolved, e.g., with ``Resolve-DNSName`` or ``nslookup`` on the Micetro Central servers.
+
+    15. Edit your Web Application ``C:\ProgramData\Men and Mice\Web Services\preferences.cfg`` file and add the following XML-tag:
+
+      .. code-block::
+        
+        <DefaultCentralServer value="your round robin record" />
+
+      For example:
+
+      .. code-block::
+
+        <DefaultCentralServer value="micetrocentral.example.com" />
+
+    16. Restart the **Men and Mice Web Services** service through the **services.msc**.
+
+    .. note::
+      Repeat these steps for each High Availability failover relationship you'd like to add. The priority for each failover member should be unique and higher than the primary.
+
+    Proceed to :ref:`dns-agent-windows`.
+
+   .. tab:: Linux
+    
+    1. On the existing (or designated as *primary*) server running Micetro Central, edit the Micetro Central preferences file in ``/var/mmsuite/mmcentral/preferences.cfg`` by adding the following XML-tag to the file:
+
+      .. code-block::
+        
+        <ClusterMemberName value="somename" />
+
+      ``somename`` is the unique name that will identify the Micetro Central instance in the High Availability cluster, e.g., "1", “primary”, or "central1". Here's an example:
+
+      .. code-block::
+        
+        <ClusterMemberName value="primary" />
+
+    2. Restart the primary Micetro Central application:
+
+      .. code-block:: bash
+        
+        systemctl restart mmcentral
+
+    3. Log into the Micetro Application as "administrator" and go to :menuselection:`Admin --> Configuration`.
+
+    4. Select :guilabel:`High Availability`.
+
+    5. Enter the name of the first member server to match the previously given name given and set the priority to **10**.
+
+    6. Select :guilabel:`Add Member`.
+
+      .. image:: ../../images/ha-add-member.jpg
+        :width: 100%
+
+    7. Restart Micetro Central:
+
+      .. code-block:: bash
+        
+        systemctl restart mmcentral
+
+    8. Log into the Micetro Web Application and navigate to :menuselection:`Admin --> Configuration --> High Availability` to verify that the current server is running with state **Active**.
+
+      .. image:: ../../images/ha-cluster.png
+        :width: 100%
+
+    9. Repeat steps 3--6 to add another member to the HA configuration, but now use a priority of **20** or higher, e.g., add a secondary server with the name "secondary" and a priority of **20**.
+
+    10. On the newly added secondary server, install Micetro Central. If it's already installed, make sure the ``mmcentral.service`` is stopped:
+    
+      .. code-block:: bash
+        
+        systemctl stop mmcentral
+        systemctl status mmcentral
+
+    11. Copy the ``/var/mmsuite/mmcentral/preferences.cfg`` file from the first server (the **Active** one) to the new secondary server to replace the secondary server's existing ``preferences.cfg`` file.
+
+      * Change the XML-tag ``ClusterMemberName`` value to the name of the secondary server that was set up in Step 9 and save the changed file.
+
+      .. note::
+        The only difference between the primary (Active) and secondary server's ``preferences.cfg`` files should be the value of ``ClusterMemberName``, e.g., *secondary* instead of *primary*.
+
+    12. Start Micetro Central on the secondary server:
+    
+      .. code-block:: bash
+        
+        systemctl start mmcentral
+
+    13. In the Web Application, navigate to :menuselection:`Admin --> Configuration --> High Availability` and verify that you now have two servers: one **Active** and one in **Standby** state.
+
+    14. Create a round robin DNS name for the High Availability setup. This involves creating two A records with the same name, each with the IP address of the primary and secondary server. For example:
+
+      .. code-block::
+        
+        micetrocentral.example.com A 192.168.2.53
+        micetrocentral.example.com A 192.168.2.54
+
+      in which ``192.168.2.53`` is the primary and ``192.168.2.54`` is the secondary. 
+
+      * Check whether the round robin name can be resolved, e.g., with ``dig`` on the two Micetro Central servers.
+
+    15. Edit your Web Application ``/var/mmsuite/mmcentral/preferences.cfg`` file and add the following XML-tag:
+
+      .. code-block::
+        
+        <DefaultCentralServer value="your round robin record" />
+  
+      For example:
+
+      .. code-block::
+
+        <DefaultCentralServer value="micetrocentral.example.com" />
+
+    16. Restart the **Men and Mice Web Services** service:
+
+      .. code-block::
+
+        systemctl start mmws
+
+    .. note::
+      Repeat these steps for each High Availability failover you'd like to add. The priority for each failover member should be unique and higher than the primary.
+
+    Proceed to :ref:`dns-agent-linux`.
+
+
 Editing HA member options
 -------------------------
 
@@ -157,11 +220,11 @@ Editing HA member options
 
 2. Select :guilabel:`High Availability`.
 
-3. Hover over the server member and use the Row :guilabel:`...` menu to select one of the following optoins:
+3. Hover over the server member and use the Row :guilabel:`...` menu to select one of the following options:
 
   * **Edit member**: Change the name or priority of the server member in the HA cluster.
    
-  * **Set active**: Set the server to be the Active member of the HA cluster manually.
+  * **Set active**: Manually set the server to be the Active member of the HA cluster.
    
   * **Remove member**: Remove the server member from the HA cluster.
 

--- a/guides/implementation/configure_linux.rst
+++ b/guides/implementation/configure_linux.rst
@@ -15,6 +15,6 @@ The following pages provide instructions on configuring Micetro on Linux. For ex
    agent_logging_linux
  
  
-For instructions on configuring High Availability for Micetro Central on Linux, refer to :ref:`central-ha-unix`.
+For instructions on configuring High Availability for Micetro Central on Linux, refer to :ref:`central-ha`.
  
 You can also integrate cloud-based DNS and DHCP services with Micetro to manage IP address data for Azure and AWS. Refer to :ref:`cloud` for more information.

--- a/guides/implementation/configure_windows.rst
+++ b/guides/implementation/configure_windows.rst
@@ -14,6 +14,6 @@ The following pages provide instructions on configuring Micetro on Windows. For 
    running_micetro_windows
    agent_logging_windows
  
-For instructions on configuring High Availability for Micetro Central on Windows, refer to :ref:`central-ha-windows`.
+For instructions on configuring High Availability for Micetro Central on Windows, refer to :ref:`central-ha`.
  
 You can also integrate cloud-based DNS and DHCP services with Micetro to manage IP address data for Azure and AWS. Refer to :ref:`cloud` for more information.

--- a/guides/implementation/install_webapp_linux.rst
+++ b/guides/implementation/install_webapp_linux.rst
@@ -106,7 +106,7 @@ To speed up response time for large operations, add the following line to ``mmws
  
 .. _webapp-fixed-central-linux:
  
-Allowing the Micetro Web Application to log into other Central servers
+Allowing the Web Application to log into other Micetro Central servers
 ----------------------------------------------------------------------
 By default, the Micetro UI and API only allow connecting to a single Micetro Central server, determined during the first login to Micetro after installation.
  
@@ -114,8 +114,17 @@ To allow users to specify a custom Central server to connect to:
  
 1. Log into the server hosting Micetro.
  
-2. Edit the ``preferences.cfg`` file for the Micetro Web Services (``/var/mmsuite/web_services/preferences.cfg``). Add the following line:
- 
+2. Edit the ``preferences.cfg`` file for the Micetro Web Services located at ``/var/mmsuite/web_services/preferences.cfg``) by adding the following line:
+
+   .. code-block::
+    
+    <DefaultCentralServer value="your Micetro Central DNS name or IP" />
+
+   .. note::
+    If ``DefaultCentralServer`` is not specified, the web service will use the first-specified Micetro Central server, typically ``localhost``.
+
+3. Add the following XML-tag to lock the web service to use the default Micetro Central server:
+
    .. code-block::
  
     <LockToDefaultServer value="0" />
@@ -126,7 +135,7 @@ To allow users to specify a custom Central server to connect to:
  
     systemctl restart mmws
  
-A :guilabel:`Server` field will appear on the Micetro login page and the :guilabel:`serverName` field in the API Login command will be honored.
+A :guilabel:`Server` field will appear on the Micetro login page and the ``serverName`` field in the API Login command will be honored.
  
 .. _webserver-proxy-timeout-linux:
  

--- a/guides/implementation/install_webapp_windows.rst
+++ b/guides/implementation/install_webapp_windows.rst
@@ -82,21 +82,30 @@ If there's already an **HTTP to HTTPS redirect** rule at the top of the list, no
  
 .. _webapp-fixed-central-windows:
  
-Allowing the Micetro Web Application to log into other Central servers
+Allowing the Web Application to log into other Micetro Central servers
 ----------------------------------------------------------------------
 By default, the Micetro UI and API only allow connecting to a single Micetro Central server, determined during the first login to Micetro after installation.
  
-To allow users to specify a custom Central server to connect to:
+To allow users to specify a custom Micetro Central server to connect to:
  
-1. Edit the ``preferences.cfg`` file for the Micetro Web Services located at ``c:\\ProgramData\\Men and Mice\\Web Services\\preferences.cfg``. Add the following line:
+1. Edit the ``preferences.cfg`` file for the Micetro Web Services located at ``c:\\ProgramData\\Men and Mice\\Web Services\\preferences.cfg`` by adding the following line to define the default Micetro Central server name:
  
    .. code-block::
-        
+    
+    <DefaultCentralServer value="your Micetro Central DNS name or IP" />
+    
+   .. note::
+    If ``DefaultCentralServer`` is not specified, the web service will use the first-specified Micetro Central server, typically ``localhost``.
+
+2. Add the following XML-tag to lock the web service to use the default Micetro Central server:
+
+   .. code-block::
+    
     <LockToDefaultServer value="0" />
  
 2. Restart the Micetro Web Services Windows service.
  
-A "Server" field will appear on the Micetro login page and the "serverName" field in the API Login command will be honored.
+A :guilabel:`Server` field will appear on the Micetro login page and the ``serverName`` field in the API Login command will be honored.
  
 .. _webserver-proxy-timeout-windows:
  


### PR DESCRIPTION
Updated the information about configuring HA for Micetro Central. Also amended the default Central servers instructions with DefaultCentralServer, which had previously been removed but was determined to be valid.